### PR TITLE
Resistor Color Trio: Typo fix in description.md

### DIFF
--- a/exercises/resistor-color-trio/description.md
+++ b/exercises/resistor-color-trio/description.md
@@ -23,7 +23,7 @@ For this exercise, you need to know only three things about them:
 - Grey: 8
 - White: 9
 
-In `resistor-color duo` you decoded the first two colors.
+In `resistor-color-duo` you decoded the first two colors.
 For instance: orange-orange got the main value `33`.
 The third color stands for how many zeros need to be added to the main value.
 The main value plus the zeros gives us a value in ohms.

--- a/exercises/resistor-color-trio/description.md
+++ b/exercises/resistor-color-trio/description.md
@@ -23,7 +23,7 @@ For this exercise, you need to know only three things about them:
 - Grey: 8
 - White: 9
 
-In `resistor-color-duo` you decoded the first two colors.
+In `Resistor Color Duo` you decoded the first two colors.
 For instance: orange-orange got the main value `33`.
 The third color stands for how many zeros need to be added to the main value.
 The main value plus the zeros gives us a value in ohms.

--- a/exercises/resistor-color-trio/description.md
+++ b/exercises/resistor-color-trio/description.md
@@ -23,7 +23,7 @@ For this exercise, you need to know only three things about them:
 - Grey: 8
 - White: 9
 
-In `Resistor Color Duo` you decoded the first two colors.
+In Resistor Color Duo you decoded the first two colors.
 For instance: orange-orange got the main value `33`.
 The third color stands for how many zeros need to be added to the main value.
 The main value plus the zeros gives us a value in ohms.


### PR DESCRIPTION
It seems the original intent here was to use the `resistor-color-duo` slug. Although I'm now wondering if this should be changed to say `Resistor Color Duo` instead of `resistor-color-duo`. The exercise name would likely be more recognizable to students than the slug.